### PR TITLE
Update the runtime to the latest stable GNOME runtime (3.30)

### DIFF
--- a/org.gnome.Maps.json
+++ b/org.gnome.Maps.json
@@ -136,8 +136,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/evolution-data-server/3.30/evolution-data-server-3.30.0.tar.xz",
-                    "sha256": "d466c1fcc4cf17e9923b7166fbd1bd66c53f518a90323fbff6ff08f74cb50dee"
+                    "url": "https://download.gnome.org/sources/evolution-data-server/3.30/evolution-data-server-3.30.3.tar.xz",
+                    "sha256": "a39c12bfc14f72a1a577a63ab1f6d4a3b77ca25df8cdc7996261993b98be3ce0"
                 }
             ]
         },
@@ -193,8 +193,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/gnome-maps/3.30/gnome-maps-3.30.0.tar.xz",
-                    "sha256": "95734f8d2790d18f2d6e7bb9eb8b771a15201938d4dd5fbba10efc4de1ae83ed"
+                    "url": "https://download.gnome.org/sources/gnome-maps/3.30/gnome-maps-3.30.3.tar.xz",
+                    "sha256": "d826c82c261db473b5330f1f2f6093fe67502b6c2e811797d90bb2efc3363368"
                 }
             ]
         }

--- a/org.gnome.Maps.json
+++ b/org.gnome.Maps.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.gnome.Maps",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "3.26",
+    "runtime-version": "3.30",
     "sdk": "org.gnome.Sdk",
     "command": "gnome-maps",
     "finish-args": [
@@ -62,12 +62,12 @@
             ]
         },
         {
-            "name": "libgee",
+            "name" : "libgee",
             "build-options" : {
-                "env": {
-                    "PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_GIRDIR": "/app/share/gir-1.0",
-                    "PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_TYPELIBDIR": "/app/lib/girepository-1.0"
-                }
+                "make-install-args" : [
+                    "girdir=/app/share/gir-1.0",
+                    "typelibdir=/app/lib/girepository-1.0"
+                ]
             },
             "sources": [
                 {
@@ -130,7 +130,8 @@
                 "-DENABLE_INTROSPECTION=ON",
                 "-DENABLE_INSTALLED_TESTS=OFF",
                 "-DENABLE_GTK_DOC=OFF",
-                "-DENABLE_EXAMPLES=OFF"
+                "-DENABLE_EXAMPLES=OFF",
+                "-DWITH_LIBDB=OFF"
             ],
             "sources": [
                 {
@@ -199,3 +200,4 @@
         }
     ]
 }
+


### PR DESCRIPTION
An attempt to fix https://github.com/flathub/flathub/issues/667
Unfortunately I was unable to update to the newest runtime (3.30) because I couldn't get that to build (due to libgee apparently)

@mlundblad let me know if you have any success with 3.30 as a runtime