### PR TITLE
Fix dbus sandbox for evolution-data-server

### DIFF
--- a/org.gnome.Maps.json
+++ b/org.gnome.Maps.json
@@ -13,7 +13,7 @@
         "--share=network",
         "--talk-name=org.gnome.OnlineAccounts",
         "--talk-name=org.gnome.evolution.dataserver.AddressBook10",
-        "--talk-name=org.gnome.evolution.dataserver.Calendar7",
+        "--talk-name=org.gnome.evolution.dataserver.Calendar8",
         "--talk-name=org.gnome.evolution.dataserver.Sources5",
         "--talk-name=org.gnome.evolution.dataserver.Subprocess.Backend.*",
         /* Work around bug 777706 */


### PR DESCRIPTION
The dbus setting `talk-name=org.gnome.evolution.dataserver.Calendar7` is
broken/out-of-date.

```
flatpak run --log-session-bus org.gnome.Maps
...
C9: -> org.freedesktop.DBus fake GetNameOwner for org.gnome.evolution.dataserver.Calendar7
...
B10: <- org.freedesktop.DBus return error org.freedesktop.DBus.Error.NameHasNoOwner from C9
...
```
Changing it to `talk-name=org.gnome.evolution.dataserver.Calendar8` fixes the issue.

```
flatpak run --log-session-bus org.gnome.Maps
...
C6: -> org.freedesktop.DBus fake GetNameOwner for org.gnome.evolution.dataserver.Calendar8
...
B7: <- org.freedesktop.DBus return from C6
...
```
Also, the setting `org.gnome.evolution.dataserver.Calendar8` is used by [org.gnome.Calendar](https://github.com/flathub/org.gnome.Calendar).