### PR TITLE
Update evolution-data-server to 3.36.3

### DIFF
--- a/org.gnome.Maps.json
+++ b/org.gnome.Maps.json
@@ -108,8 +108,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/evolution-data-server/3.36/evolution-data-server-3.36.2.tar.xz",
-                    "sha256": "98e274cfec16cee6a4b3b9c7897f6e1136d00e4f31a0d66214925abbac76e97b"
+                    "url": "https://download.gnome.org/sources/evolution-data-server/3.36/evolution-data-server-3.36.3.tar.xz",
+                    "sha256": "1f5f48173d0f288219d73d4f193cb921ae631932ba84030f05751c42bb003db2"
                 }
             ],
             "modules":[


### PR DESCRIPTION
We should keep evolution-data-server up to date with the version in most distros, to prevent breakage. 3.36.3 is in Fedora 32 and all rolling release distros.