### PR TITLE
Use shared-modules for libcanberra and clutter

### DIFF
--- a/org.gnome.Maps.json
+++ b/org.gnome.Maps.json
@@ -185,45 +185,7 @@
                 }
             ]
         },
-        {
-            "name": "cogl",
-            "config-opts": [
-                "--disable-cogl-gst",
-                "--enable-xlib-egl-platform",
-                "--enable-wayland-egl-platform"
-            ],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://download.gnome.org/sources/cogl/1.22/cogl-1.22.8.tar.xz",
-                    "sha256": "a805b2b019184710ff53d0496f9f0ce6dcca420c141a0f4f6fcc02131581d759"
-                }
-            ]
-        },
-        {
-            "name": "clutter",
-            "config-opts": [
-                "--enable-egl-backend",
-                "--enable-wayland-backend"
-            ],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://download.gnome.org/sources/clutter/1.26/clutter-1.26.4.tar.xz",
-                    "sha256": "8b48fac159843f556d0a6be3dbfc6b083fc6d9c58a20a49a6b4919ab4263c4e6"
-                }
-            ]
-        },
-        {
-            "name": "clutter-gtk",
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://download.gnome.org/sources/clutter-gtk/1.8/clutter-gtk-1.8.4.tar.xz",
-                    "sha256": "521493ec038973c77edcb8bc5eac23eed41645117894aaee7300b2487cb42b06"
-                }
-            ]
-        },
+        "shared-modules/clutter/clutter.json",
         {
             "name": "libchamplain",
             "buildsystem": "meson",

--- a/org.gnome.Maps.json
+++ b/org.gnome.Maps.json
@@ -110,17 +110,7 @@
                 }
             ]
         },
-        {
-            "name": "libcanberra-gtk3",
-            "buildsystem": "autotools",
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "http://0pointer.de/lennart/projects/libcanberra/libcanberra-0.30.tar.xz",
-                    "sha256": "c2b671e67e0c288a69fc33dc1b6f1b534d07882c2aceed37004bf48c601afa72"
-                }
-            ]
-        },
+        "shared-modules/libcanberra/libcanberra.json",
         {
             "name": "evolution-data-server",
             "cleanup": [


### PR DESCRIPTION
Includes relevant patch that fixes libcanberra use in wayland.