### PR TITLE
x-checker-data: Only update on Maps updates

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "require-important-update": true
+}

--- a/org.gnome.Maps.json
+++ b/org.gnome.Maps.json
@@ -123,6 +123,7 @@
                     "sha256": "6003eb73dd9fd269b4a91bed9bf03ee9ab240c5124eedabf28be22a3fefba595",
                     "x-checker-data": {
                         "type": "gnome",
+                        "is-important": true,
                         "name": "gnome-maps"
                     }
                 }


### PR DESCRIPTION
Only creates a MR when gnome-maps is updated, this PR will contain all other releases.